### PR TITLE
Fix: Resolve NameError in validator worker thread

### DIFF
--- a/validator.py
+++ b/validator.py
@@ -8,6 +8,7 @@ import time
 import asyncio
 import copy
 import json
+import numpy as np 
 
 import bittensor as bt
 import torch


### PR DESCRIPTION

**Issue:**

A critical NameError: name 'np' is not defined was occurring in the validator's weight calculation worker thread. This error was caused by the use of a NumPy function (np.any) without importing the library beforehand in the validator.py file.

**Solution:**

This PR resolves the issue by adding the missing import numpy as np statement at the top of validator.py. This simple change ensures the NumPy library is available within the script, eliminating the NameError and restoring the correct functionality of the weight-setting mechanism.